### PR TITLE
Implement DocCrawler CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ mvn spring-boot:run
 ```
 
 The project includes dependencies for LangChain4j, pgvector-jdbc and the OpenAI SDK.
+
+## Crawling documentation
+
+The `DocCrawler` CLI reads `urls.txt`, downloads each URL and stores the result under `corpus/raw/`.
+
+Run it with:
+
+```bash
+mvn -q exec:java -Dexec.mainClass=com.example.docs.DocCrawler
+```

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,16 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-html2md</artifactId>
+            <version>0.64.8</version>
+        </dependency>
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
             <version>0.28.0</version>

--- a/src/main/java/com/example/docs/DocCrawler.java
+++ b/src/main/java/com/example/docs/DocCrawler.java
@@ -1,0 +1,108 @@
+package com.example.docs;
+
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+
+public class DocCrawler {
+    private static final Logger log = LoggerFactory.getLogger(DocCrawler.class);
+
+    public static void main(String[] args) throws Exception {
+        Path urlsFile = Paths.get("urls.txt");
+        if (!Files.exists(urlsFile)) {
+            log.error("urls.txt not found");
+            return;
+        }
+        List<String> urls = Files.readAllLines(urlsFile, StandardCharsets.UTF_8);
+        for (String url : urls) {
+            url = url.trim();
+            if (url.isEmpty()) {
+                continue;
+            }
+            try {
+                fetch(url);
+            } catch (Exception e) {
+                log.error("Failed to fetch {}", url, e);
+            }
+        }
+    }
+
+    private static void fetch(String url) throws IOException, URISyntaxException {
+        log.info("Fetching {}", url);
+        Connection connection = Jsoup.connect(url).ignoreContentType(true);
+        Connection.Response response = connection.execute();
+
+        String contentTypeHeader = Optional.ofNullable(response.contentType()).orElse("").toLowerCase();
+        String type;
+        String body;
+        if (contentTypeHeader.contains("text/html")) {
+            Document doc = response.parse();
+            doc.select("nav, aside, footer").remove();
+            body = FlexmarkHtmlConverter.builder().build().convert(doc.html());
+            type = "html";
+        } else if (contentTypeHeader.contains("markdown")) {
+            body = response.body();
+            type = "markdown";
+        } else {
+            body = response.body();
+            type = "text";
+        }
+
+        String fetchedAt = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        StringBuilder sb = new StringBuilder();
+        sb.append("---\n");
+        sb.append("source: ").append(url).append('\n');
+        sb.append("fetchedAt: ").append(fetchedAt).append('\n');
+        sb.append("contentType: ").append(type).append('\n');
+        sb.append("---\n\n");
+        sb.append(body);
+
+        Path output = Paths.get("corpus/raw").resolve(buildPath(url, contentTypeHeader, type));
+        Files.createDirectories(output.getParent());
+        Files.writeString(output, sb.toString(), StandardCharsets.UTF_8);
+        log.info("Saved {}", output);
+    }
+
+    private static Path buildPath(String url, String contentTypeHeader, String type) throws URISyntaxException {
+        URI uri = new URI(url);
+        String host = Optional.ofNullable(uri.getHost()).orElse("unknown");
+        String path = Optional.ofNullable(uri.getPath()).orElse("");
+        if (path.isEmpty()) {
+            path = "/index";
+        }
+        if (path.endsWith("/")) {
+            path += "index";
+        }
+        Path p = Paths.get(host, path).normalize();
+        String fileName = p.getFileName().toString();
+        if (type.equals("html") || type.equals("markdown")) {
+            if (!fileName.endsWith(".md")) {
+                fileName += ".md";
+            }
+        } else if (type.equals("text")) {
+            if (!fileName.endsWith(".txt")) {
+                fileName += ".txt";
+            }
+        }
+        Path parent = p.getParent();
+        if (parent == null) {
+            return Paths.get(fileName);
+        }
+        return parent.resolve(fileName);
+    }
+}


### PR DESCRIPTION
## Summary
- add DocCrawler class for crawling URLs from `urls.txt`
- save downloaded content under `corpus/raw/` with front matter
- convert HTML to Markdown using flexmark
- include jsoup and flexmark dependencies
- document DocCrawler usage in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eb5bd4148323b8aadc56f281af05