### PR TITLE
Add optional delay for crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ Run it with:
 ```bash
 mvn -q exec:java -Dexec.mainClass=com.example.docs.DocCrawler
 ```
+
+You can optionally specify a delay between requests (in milliseconds) by
+passing a single argument. For example, to pause for one second between
+requests:
+
+```bash
+mvn -q exec:java -Dexec.mainClass=com.example.docs.DocCrawler -Dexec.args="1000"
+```

--- a/src/main/java/com/example/docs/DocCrawler.java
+++ b/src/main/java/com/example/docs/DocCrawler.java
@@ -23,6 +23,19 @@ public class DocCrawler {
     private static final Logger log = LoggerFactory.getLogger(DocCrawler.class);
 
     public static void main(String[] args) throws Exception {
+        long delayMs = 0;
+        if (args.length > 0) {
+            try {
+                delayMs = Long.parseLong(args[0]);
+                if (delayMs < 0) {
+                    log.warn("Delay must be non-negative, using 0");
+                    delayMs = 0;
+                }
+            } catch (NumberFormatException e) {
+                log.warn("Invalid delay value: {}", args[0]);
+            }
+        }
+
         Path urlsFile = Paths.get("urls.txt");
         if (!Files.exists(urlsFile)) {
             log.error("urls.txt not found");
@@ -36,6 +49,9 @@ public class DocCrawler {
             }
             try {
                 fetch(url);
+                if (delayMs > 0) {
+                    Thread.sleep(delayMs);
+                }
             } catch (Exception e) {
                 log.error("Failed to fetch {}", url, e);
             }


### PR DESCRIPTION
## Summary
- add optional delay parameter for DocCrawler and wait after each request
- document usage of the delay flag in README

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489185f0fc8323b774f79daabbfdfb