### PR TITLE
Implement PreprocessRunner CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ requests:
 ```bash
 mvn -q exec:java -Dexec.mainClass=com.example.docs.DocCrawler -Dexec.args="1000"
 ```
+
+## Preprocessing Markdown
+
+`PreprocessRunner` splits the downloaded Markdown into token-limited chunks.
+It reads every `*.md` under `corpus/raw`, strips YAML front matter and any
+`<nav>`, `<aside>` or `<footer>` sections, then uses LangChain4j's recursive
+splitter with a chunk size of 1024 tokens, an overlap of 128 tokens and the
+GPT-4o tokenizer. Each chunk becomes a JSON file in `corpus/chunked` containing
+`id`, `text`, `tokens`, `source`, `chunkIndex` and `totalChunks`. Progress is
+logged as `splitting {file} → {n} chunks`.
+
+Run it with:
+
+```bash
+mvn -q exec:java -Dexec.mainClass=com.example.docs.PreprocessRunner
+```

--- a/src/main/java/com/example/docs/PreprocessRunner.java
+++ b/src/main/java/com/example/docs/PreprocessRunner.java
@@ -1,0 +1,85 @@
+package com.example.docs;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.splitter.DocumentSplitter;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.model.tokenization.Tokenizer;
+import dev.langchain4j.model.tokenization.openai.OpenAiTokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+public class PreprocessRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(PreprocessRunner.class);
+
+    private static final Pattern YAML_FRONT_MATTER = Pattern.compile("(?s)^---\\n.*?\\n---\\n");
+    private static final Pattern NAV = Pattern.compile("(?is)<nav.*?</nav>");
+    private static final Pattern ASIDE = Pattern.compile("(?is)<aside.*?</aside>");
+    private static final Pattern FOOTER = Pattern.compile("(?is)<footer.*?</footer>");
+
+    public static void main(String[] args) throws IOException {
+        Path rawDir = Paths.get("corpus/raw");
+        Path outDir = Paths.get("corpus/chunked");
+        Tokenizer tokenizer = OpenAiTokenizer.GPT_4O;
+        DocumentSplitter splitter = DocumentSplitters.recursive(1024, 128, tokenizer);
+
+        List<Path> files = new ArrayList<>();
+        if (Files.exists(rawDir)) {
+            try (var stream = Files.walk(rawDir)) {
+                stream.filter(p -> p.toString().endsWith(".md"))
+                        .forEach(files::add);
+            }
+        }
+
+        for (Path file : files) {
+            String text = Files.readString(file, StandardCharsets.UTF_8);
+            text = YAML_FRONT_MATTER.matcher(text).replaceFirst("");
+            text = NAV.matcher(text).replaceAll("");
+            text = ASIDE.matcher(text).replaceAll("");
+            text = FOOTER.matcher(text).replaceAll("");
+
+            Document document = Document.from(text);
+            List<Document> chunks = splitter.split(document);
+            log.info("splitting {} → {} chunks", file, chunks.size());
+
+            Path relative = rawDir.relativize(file);
+            String baseName = relative.toString();
+            if (baseName.endsWith(".md")) {
+                baseName = baseName.substring(0, baseName.length() - 3);
+            }
+            for (int i = 0; i < chunks.size(); i++) {
+                Document chunk = chunks.get(i);
+                int tokens = tokenizer.estimateTokenCountInText(chunk.text());
+                String id = UUID.randomUUID().toString();
+                Path chunkPath = outDir.resolve(baseName + "-" + i + ".json");
+                Files.createDirectories(chunkPath.getParent());
+                String json = "{" +
+                        "\"id\":\"" + id + "\"," +
+                        "\"text\":\"" + escapeJson(chunk.text()) + "\"," +
+                        "\"tokens\":" + tokens + ',' +
+                        "\"source\":\"" + relative + "\"," +
+                        "\"chunkIndex\":" + i + ',' +
+                        "\"totalChunks\":" + chunks.size() +
+                        "}";
+                Files.writeString(chunkPath, json, StandardCharsets.UTF_8);
+            }
+        }
+    }
+
+    private static String escapeJson(String text) {
+        return text.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n");
+    }
+}
+

--- a/src/test/java/com/example/docs/SplitterTest.java
+++ b/src/test/java/com/example/docs/SplitterTest.java
@@ -1,0 +1,42 @@
+package com.example.docs;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.splitter.DocumentSplitter;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.model.tokenization.Tokenizer;
+import dev.langchain4j.model.tokenization.openai.OpenAiTokenizer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SplitterTest {
+
+    @Test
+    void splitRespectsSizeAndOverlap() {
+        Tokenizer tokenizer = OpenAiTokenizer.GPT_4O;
+        DocumentSplitter splitter = DocumentSplitters.recursive(10, 2, tokenizer);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 30; i++) {
+            sb.append("word").append(i).append(' ');
+        }
+        Document doc = Document.from(sb.toString());
+        List<Document> chunks = splitter.split(doc);
+        assertTrue(chunks.size() > 1);
+
+        for (Document chunk : chunks) {
+            int tokens = tokenizer.estimateTokenCountInText(chunk.text());
+            assertTrue(tokens <= 10);
+        }
+
+        List<Integer> first = tokenizer.encode(chunks.get(0).text());
+        List<Integer> second = tokenizer.encode(chunks.get(1).text());
+        int overlap = 2;
+        List<Integer> tail = first.subList(first.size() - overlap, first.size());
+        List<Integer> head = second.subList(0, overlap);
+        assertEquals(tail, head);
+    }
+}


### PR DESCRIPTION
## Summary
- add `PreprocessRunner` CLI that splits Markdown files
- output JSON chunks in `corpus/chunked`
- log progress and clean front matter & navigation markup
- add unit test `SplitterTest`
- document usage of `PreprocessRunner`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848981e7a208323a3077e57f481ed35