### PR TITLE
Update LangChain4j dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Minimal Spring Boot skeleton using JDK 21 and Maven.
 mvn spring-boot:run
 ```
 
-The project includes dependencies for LangChain4j, pgvector-jdbc and the OpenAI SDK.
+The project includes dependencies for LangChain4j (version 0.29.0 or later), pgvector-jdbc and the OpenAI SDK.
 
 ## Crawling documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>0.28.0</version>
+            <version>0.29.0</version>
         </dependency>
         <dependency>
             <groupId>com.pgvector</groupId>


### PR DESCRIPTION
## Summary
- use langchain4j 0.29.0 to compile GPT-4o code
- document required LangChain4j version

## Testing
- `mvn -q exec:java -Dexec.mainClass=com.example.docs.PreprocessRunner` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489c3b13ac8323b833c9faa3b0bc0c