### PR TITLE
Update to langchain4j 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Minimal Spring Boot skeleton using JDK 21 and Maven.
 mvn spring-boot:run
 ```
 
-The project includes dependencies for LangChain4j (version 0.29.0 or later), pgvector-jdbc and the OpenAI SDK.
+The project includes dependencies for LangChain4j (version 1.0.1 or later), pgvector-jdbc and the OpenAI SDK.
 
 ## Crawling documentation
 
@@ -35,9 +35,9 @@ mvn -q exec:java -Dexec.mainClass=com.example.docs.DocCrawler -Dexec.args="1000"
 
 `PreprocessRunner` splits the downloaded Markdown into token-limited chunks.
 It reads every `*.md` under `corpus/raw`, strips YAML front matter and any
-`<nav>`, `<aside>` or `<footer>` sections, then uses LangChain4j's recursive
-splitter with a chunk size of 1024 tokens, an overlap of 128 tokens and the
-GPT-4o tokenizer. Each chunk becomes a JSON file in `corpus/chunked` containing
+`<nav>`, `<aside>` or `<footer>` sections, then uses LangChain4j's
+`RecursiveDocumentSplitter` with a chunk size of 1024 tokens, an overlap of 128
+tokens and the GPT-4o tokenizer. Each chunk becomes a JSON file in `corpus/chunked` containing
 `id`, `text`, `tokens`, `source`, `chunkIndex` and `totalChunks`. Progress is
 logged as `splitting {file} → {n} chunks`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>0.29.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.pgvector</groupId>

--- a/src/main/java/com/example/docs/PreprocessRunner.java
+++ b/src/main/java/com/example/docs/PreprocessRunner.java
@@ -1,10 +1,9 @@
 package com.example.docs;
 
 import dev.langchain4j.data.document.Document;
-import dev.langchain4j.data.document.splitter.DocumentSplitter;
-import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.document.splitter.RecursiveDocumentSplitter;
 import dev.langchain4j.model.tokenization.Tokenizer;
-import dev.langchain4j.model.tokenization.openai.OpenAiTokenizer;
+import dev.langchain4j.model.openai.tokenization.OpenAiTokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +29,12 @@ public class PreprocessRunner {
     public static void main(String[] args) throws IOException {
         Path rawDir = Paths.get("corpus/raw");
         Path outDir = Paths.get("corpus/chunked");
-        Tokenizer tokenizer = OpenAiTokenizer.GPT_4O;
-        DocumentSplitter splitter = DocumentSplitters.recursive(1024, 128, tokenizer);
+        Tokenizer tokenizer = OpenAiTokenizer.gpt4o();
+        RecursiveDocumentSplitter splitter = RecursiveDocumentSplitter.builder()
+                .chunkSize(1024)
+                .chunkOverlap(128)
+                .tokenizer(tokenizer)
+                .build();
 
         List<Path> files = new ArrayList<>();
         if (Files.exists(rawDir)) {

--- a/src/test/java/com/example/docs/SplitterTest.java
+++ b/src/test/java/com/example/docs/SplitterTest.java
@@ -1,10 +1,9 @@
 package com.example.docs;
 
 import dev.langchain4j.data.document.Document;
-import dev.langchain4j.data.document.splitter.DocumentSplitter;
-import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.document.splitter.RecursiveDocumentSplitter;
 import dev.langchain4j.model.tokenization.Tokenizer;
-import dev.langchain4j.model.tokenization.openai.OpenAiTokenizer;
+import dev.langchain4j.model.openai.tokenization.OpenAiTokenizer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -16,8 +15,12 @@ class SplitterTest {
 
     @Test
     void splitRespectsSizeAndOverlap() {
-        Tokenizer tokenizer = OpenAiTokenizer.GPT_4O;
-        DocumentSplitter splitter = DocumentSplitters.recursive(10, 2, tokenizer);
+        Tokenizer tokenizer = OpenAiTokenizer.gpt4o();
+        RecursiveDocumentSplitter splitter = RecursiveDocumentSplitter.builder()
+                .chunkSize(10)
+                .chunkOverlap(2)
+                .tokenizer(tokenizer)
+                .build();
 
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 30; i++) {


### PR DESCRIPTION
## Summary
- bump langchain4j to `1.0.1`
- use `RecursiveDocumentSplitter` and new tokenizer API
- update preprocessing logic and tests
- document required version in README

## Testing
- `mvn clean test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd6070ccc8323b37f664cefc5d1dc