### PR TITLE
Fix SplitterTest

### DIFF
--- a/src/test/java/com/example/docs/SplitterTest.java
+++ b/src/test/java/com/example/docs/SplitterTest.java
@@ -22,7 +22,8 @@ class SplitterTest {
 
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 30; i++) {
-            sb.append("word").append(i).append(' ');
+            sb.append("word").append(i);
+            if (i < 29) sb.append(' ');
         }
         Document doc = Document.from(sb.toString());
         List<TextSegment> chunks = splitter.split(doc);
@@ -33,8 +34,8 @@ class SplitterTest {
             assertTrue(tokens <= 10);
         }
 
-        List<Integer> first = estimator.encode(chunks.get(0).text());
-        List<Integer> second = estimator.encode(chunks.get(1).text());
+        List<Integer> first = estimator.encode(chunks.get(0).text().trim());
+        List<Integer> second = estimator.encode(chunks.get(1).text().trim());
         int overlap = 2;
         List<Integer> tail = first.subList(first.size() - overlap, first.size());
         List<Integer> head = second.subList(0, overlap);


### PR DESCRIPTION
## Summary
- ensure word separation loop omits trailing spaces
- trim chunk text before token encoding

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de72dc5a08323998f741bde0b8874